### PR TITLE
list composer as a suggest package instead of forcing it in the development packages list

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,9 +31,6 @@
     "Suggests": {
         "respect/validation": "^2.3"
     },
-    "conflict": {
-        "respect/validation": "<2.3|| >=3.0"
-    },
     "autoload": {
         "psr-4": {
             "Chubbyphp\\Parsing\\": "src/"

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,9 @@
         "php-coveralls/php-coveralls": "^2.7.0",
         "phpstan/extension-installer": "^1.3.1",
         "phpstan/phpstan": "^1.10.45",
-        "phpunit/phpunit": "^10.4.2",
+        "phpunit/phpunit": "^10.4.2"
+    },
+    "Suggests": {
         "respect/validation": "^2.3"
     },
     "conflict": {


### PR DESCRIPTION
In this pr we remove respect validation from the development list of packages

## Why

Although I understand your reasoning to put this package in dev dependencies, it creates issues for those users who do not whish to use respect validation as part of your package.

This happens for example when there are respect validations which are not compatible to the versions you require, which effectively presents this package to be installed.

Respect validation is effectively a peer dependency, you make it clear in Readme as you instruct users to make a composer require.

However, by letting the package in dev dependencies,, because virtually everyone uses dev dependencies oin their environments, you are making respect validation a effectively required dependency, unless a project uses only production dependencies even in its development cycle.

The only small "draw back" of putting thisdependency in suggested (as a peer dependency, where it must be) is that contributors will have to install the respect validation before running tests. But the number of contributors is way smaller than the number of users, and contributors are expected to understand how to install a peer dependenci when tests requiring it fail.


